### PR TITLE
Add route

### DIFF
--- a/cost-analyzer/templates/NOTES.txt
+++ b/cost-analyzer/templates/NOTES.txt
@@ -10,10 +10,20 @@ If you have configured cloud-integrations, it can take up to 48 hours for cost r
 
 When using Durable storage (Enterprise Edition), please allow up to 4 hours for data to be collected and the UI to be healthy.
 
+{{- if and .Values.route
+           .Values.route.enabled }}
+  {{ if .Values.route.host }}
+When pods are Ready, you can open a browser to https://{{ .Values.route.host }}
+  {{ else }}
+When pods are Ready, you can find out the hostname which kubecost will serve with the following command:
+
+    kubectl --namespace {{ .Release.Namespace }} get route {{ template "cost-analyzer.fullname" . }}-route -o jsonpath='{.status.ingress[0].host}'
+  {{ end }}
+{{- else -}}
 When pods are Ready, you can enable port-forwarding with the following command:
 
     kubectl port-forward --namespace {{ .Release.Namespace }} deployment/{{ template "cost-analyzer.fullname" . }} {{ $servicePort }}
 
 Next, navigate to http://localhost:{{ $servicePort }} in a web browser.
-
+{{- end }}
 Having installation issues? View our Troubleshooting Guide at http://docs.kubecost.com/troubleshoot-install

--- a/cost-analyzer/templates/cost-analyzer-route.yaml
+++ b/cost-analyzer/templates/cost-analyzer-route.yaml
@@ -15,7 +15,7 @@ spec:
   host: "{{ .Values.route.host }}"
   {{- end }}
   port:
-    targetPort: 9090
+    targetPort: tcp-frontend
   tls:
     termination: edge
   to:

--- a/cost-analyzer/templates/cost-analyzer-route.yaml
+++ b/cost-analyzer/templates/cost-analyzer-route.yaml
@@ -12,9 +12,7 @@ metadata:
   {{- end }}
 spec:
   {{ if .Values.route.host }}
-  host: "{{ .Values.route.host }}""
-  {{- else }}
-  host: "kubecost-{{ .Release.Namespace }}.apps.okd4.example.com"
+  host: "{{ .Values.route.host }}"
   {{- end }}
   port:
     targetPort: 9090

--- a/cost-analyzer/templates/cost-analyzer-route.yaml
+++ b/cost-analyzer/templates/cost-analyzer-route.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.route
+           .Values.route.enabled -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "cost-analyzer.fullname" . }}-route
+  labels:
+    {{ include "cost-analyzer.commonLabels" . | nindent 4 }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{ if .Values.route.host }}
+  host: "{{ .Values.route.host }}""
+  {{- else }}
+  host: "kubecost-{{ .Release.Namespace }}.apps.okd4.example.com"
+  {{- end }}
+  port:
+    targetPort: 9090
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ template "cost-analyzer.serviceName" . }}
+    weight: 100
+  wildcardPolicy: None
+{{- end }}

--- a/values-openshift.yaml
+++ b/values-openshift.yaml
@@ -1,5 +1,5 @@
 route:
-  enabled: true
+  enabled: false
   annotations: {}
   # Add custom dns URL for your route.
   # Example:

--- a/values-openshift.yaml
+++ b/values-openshift.yaml
@@ -1,3 +1,6 @@
+route:
+  enabled: true
+
 # Security Context settings for Redhat OpenShift cluster:
 kubecostProductConfigs:
   clusterName: YOUR_CLUSTER_NAME

--- a/values-openshift.yaml
+++ b/values-openshift.yaml
@@ -1,5 +1,9 @@
 route:
   enabled: true
+  annotations: {}
+  # Add custom dns URL for your route.
+  # Example:
+  # host: kubecost.apps.okd4.example.com
 
 # Security Context settings for Redhat OpenShift cluster:
 kubecostProductConfigs:


### PR DESCRIPTION
Add a route to expose kubecost.

# How is this PR tested
There are three states for this PR to be tested in.

## No route
Install using `helm upgrade -i kubecost cost-analyzer -f ./values-openshift.yaml` and verify that there is no route.

## Route but no specific hostname
Install using `helm upgrade -i kubecost cost-analyzer -f ./values-openshift.yaml  --set route.enabled=true`

Verify there is a route:
`kubectl get route`

Verify that you can browse to the following address:
`kubectl get route kubecost-cost-analyzer-route -o jsonpath='{.status.ingress[0].host}'`

## Route with specific host
Install using `helm upgrade -i kubecost cost-analyzer -f ./values-openshift.yaml --set route.enabled=true --set route.host=hostname.apps.okd4.example.com`

Verify there is a route:
`kubectl get route`

Verify that you can browse to the address specifiked during installation.