### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/cost-analyzer/charts/prometheus/charts/kube-state-metrics/values.yaml
+++ b/cost-analyzer/charts/prometheus/charts/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 # Default values for kube-state-metrics.
 prometheusScrape: true
 image:
-  repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
+  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
   tag: v1.9.8
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.